### PR TITLE
Add CXX flags to Cmake file

### DIFF
--- a/RevisionControl/Cxx/CMakeLists.txt
+++ b/RevisionControl/Cxx/CMakeLists.txt
@@ -1,5 +1,9 @@
 PROJECT(GitStatistics)
 
+SET(
+  CMAKE_CXX_FLAGS "-std=c++11"
+  )
+
 ADD_EXECUTABLE(GitStatisticsAnalyzer
   AuthorChanges.cxx
   GitNetwork.cxx


### PR DESCRIPTION
As already mentioned in the README, -std=c++11 has to be passed to the
compiler in order to build the project. This patch adds the respective
setting to the buildsystem.
